### PR TITLE
投稿されたメッセージの表示

### DIFF
--- a/app/assets/stylesheets/_chats.scss
+++ b/app/assets/stylesheets/_chats.scss
@@ -2,6 +2,8 @@
   background-color: #fafafa;
   height: calc(100% - 246px);
   padding: 46px 40px 0;
+  margin: 100px 0;
+  overflow: scroll;
 
   &__chat{
     margin-bottom: 40px;
@@ -24,6 +26,9 @@
     &__message{
       @include fontsize_color(14px, #434a54);
       clear: both;
+      // &__image{
+      //   @include width_height(100px, 100px);
+      // }
     }
   }
 }

--- a/app/assets/stylesheets/_form.scss
+++ b/app/assets/stylesheets/_form.scss
@@ -1,8 +1,10 @@
 .form{
   background-color: silver;
-  height: 100px;
+  @include width_height(calc(100% - 380px), 100px);
   padding: 0 40px;
   position: relative;
+  position: fixed;
+  bottom: 0;
 
   &__new-message{
     position: absolute;

--- a/app/assets/stylesheets/_main-header.scss
+++ b/app/assets/stylesheets/_main-header.scss
@@ -1,7 +1,9 @@
 .main-header{
-  height: 100px;
+  @include width_height(calc(100% - 380px), 100px);
+  background-color: white;
   padding: 0 40px;
   border-bottom: solid 1px #eeeeee;
+  position: fixed;
 
   &__current-group{
     float: left;

--- a/app/assets/stylesheets/_side-groups.scss
+++ b/app/assets/stylesheets/_side-groups.scss
@@ -1,7 +1,9 @@
 .side-groups{
   background-color: #2f3e51;
-  @include width_height(calc(100% - 40px), calc(100% - 100px));
+  @include width_height(calc(100% - 40px), calc(100vh - 100px));
   padding: 0 20px;
+  margin-top: 100px;
+  overflow: scroll;
 
     &__group{
       padding: 20px 0;

--- a/app/assets/stylesheets/_side-header.scss
+++ b/app/assets/stylesheets/_side-header.scss
@@ -1,8 +1,10 @@
 .side-header{
   background-color: #253141;
-  width: calc(100% - 40px);
+  width: calc(300px - 40px);
   height: 100px;
   padding: 0 20px;
+  position: fixed;
+  top: 0;
 
   &__user-name{
     float: left;

--- a/app/uploaders/image_uploader.rb
+++ b/app/uploaders/image_uploader.rb
@@ -3,7 +3,7 @@ class ImageUploader < CarrierWave::Uploader::Base
   # include CarrierWave::RMagick
   include CarrierWave::MiniMagick
 
-  process resize_to_fit: [800, 800]
+  process resize_to_fit: [200, 200]
 
   # Choose what kind of storage to use for this uploader:
   storage :file

--- a/app/views/messages/_chats__chat.html.haml
+++ b/app/views/messages/_chats__chat.html.haml
@@ -1,5 +1,11 @@
 .chats__chat
   .chats__chat__upper-info
-    %p.chats__chat__upper-info__user-name test-user
-    %p.chats__chat__upper-info__date 2019/05/01/(Wed) 00:00:00
-  %p.chats__chat__message ようこそ令和
+    .chats__chat__upper-info__user-name
+      = message.user.name
+    .chats__chat__upper-info__date
+      = message.created_at.strftime("%Y/%m/%d %H:%M")
+  .chats__chat__message
+    .chats__chat__message__text
+      = message.text
+    .chats__chat__message__image
+      = image_tag message.image.url if message.image.present?

--- a/app/views/messages/index.html.haml
+++ b/app/views/messages/index.html.haml
@@ -12,9 +12,7 @@
       =link_to "Edit", root_path, class: "group-edit-btn" 
 
   .chats
-    =render partial: "messages/chats__chat"
-    =render partial: "messages/chats__chat"
-    =render partial: "messages/chats__chat"
+    = render partial: "messages/chats__chat", collection: @messages, as: "message"
 
   .form
     .form__new-message


### PR DESCRIPTION
# WHAT
投稿されたメッセージのビュー画面での表示
messages#indexからパーシャル処理

_side-headerの固定
_side-groupsのスクロール処理

_main-headerの固定
_chatsのスクロール処理
_formの固定

image_uploaderで画像のリサイズ値の変更

# WHY
投稿されたメッセージを表示するため
メッセージが増えた時にスクロール表示できるようにするため
グループ数が増えた時にスクロール表示できるようにするため
投稿された画像のサイズを最適化するため