### PR TITLE
細かい部分の修正

### DIFF
--- a/app/assets/stylesheets/_flash.scss
+++ b/app/assets/stylesheets/_flash.scss
@@ -1,6 +1,10 @@
 .flash {
   color: white;
   text-align: center;
+  position: fixed;
+  top: 0;
+  z-index: 10;
+  width: 100%;
   &__alert{
     background-color: red;
   }

--- a/app/assets/stylesheets/_form.scss
+++ b/app/assets/stylesheets/_form.scss
@@ -16,15 +16,17 @@
     
     &__input-box{
       background-color: white;
-      height: 50px;
-      width: calc(90% - 15px);
+      @include width_height(calc(90% - 15px), 50px);
       line-height: 50px;
       float: left;
       margin-right: 15px;
       
       &__text{
         float: left;
+        @include width_height(calc(90% - 15px), 48px);
         @include fontsize_color(16px, $text-color);
+        // opacity: 0.5;
+        border: none;
         padding-left: 10px;
       }
       &__img{

--- a/app/assets/stylesheets/_main-header.scss
+++ b/app/assets/stylesheets/_main-header.scss
@@ -4,6 +4,7 @@
   padding: 0 40px;
   border-bottom: solid 1px #eeeeee;
   position: fixed;
+  top: 0;
 
   &__current-group{
     float: left;

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -4,4 +4,14 @@ class Group < ApplicationRecord
   has_many :messages
 
   validates :name, presence: true
+
+  def show_lase_message
+    # 最後のメッセージをlase_message変数に入れつつ、あるかどうかを判定
+    if (last_message = messages.last).present?
+      # 三項演算子　条件式 ? trueの時の値 : falseの時の値
+      last_message.text? ? last_message.text : "画像が投稿されています"
+    else
+      "まだメッセージはありません"
+    end
+  end
 end

--- a/app/views/messages/_sub_window.html.haml
+++ b/app/views/messages/_sub_window.html.haml
@@ -17,4 +17,5 @@
           .side-groups__group__name
             = group.name
           .side-groups__group__latest-message
-            メッセージはまだありません。 
+            -# groupモデルのインスタンスメソッドの呼び出し
+            = group.show_lase_message


### PR DESCRIPTION
# WHAT
groupモデルクラスの中に、サブウインドウにグループの最新メッセージを表示できるようにメソッドの定義
ビューからメソッドの呼び出し

_form.scssの修正
フラッシュメッセージの固定
_main_headerの固定

# WHY
機能向上のため
フラッシュメッセージの表示によってビュー画面が崩れるのを防ぐため